### PR TITLE
fix(docs): Exclude ADRs directory from Jekyll build

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -114,3 +114,7 @@ exclude:
   - user-guides/
   - vault-setup/
   - internal/
+  # ADRs contain complex code examples (Python f-strings, Jinja2/Ansible templates)
+  # Many use {{ }} patterns that conflict with Jekyll's Liquid templating
+  # ADRs are accessible directly from GitHub repository
+  - adrs/


### PR DESCRIPTION
## Summary
- Excludes the entire `adrs/` directory from Jekyll processing

## Problem
ADRs contain complex code examples including:
- Python f-strings with `{variable}` syntax
- Jinja2/Ansible templates with `{{ variable | filter }}` syntax  
- GitHub Actions syntax with `${{ steps.*.outputs.* }}`

These `{{ }}` patterns conflict with Jekyll's Liquid templating and cause build failures like:
```
Liquid syntax error (line 624): Variable '{{
    echo "[ERROR] Deploy script not found: {script_path}' was not properly terminated
```

## Solution
Exclude the entire `adrs/` directory from Jekyll processing. ADRs are internal architecture decision records that are still accessible directly from the GitHub repository.

## Changes
- Updated `docs/_config.yml` to add `adrs/` to the exclude list

## Testing
CI will validate the Jekyll build passes.

## Related Issues
Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)