### PR TITLE
Fix airflow dag import errors

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -19,7 +19,11 @@ RUN pip install --no-cache-dir \
     pgvector>=0.2.0 \
     psycopg2-binary>=2.9.0 \
     # Pydantic for data validation
-    pydantic>=2.0.0
+    pydantic>=2.0.0 \
+    # YAML parsing for dag_factory registry support
+    pyyaml>=6.0.0 \
+    # Graphviz for DAG visualization (optional but recommended)
+    graphviz>=0.20.0
 
 # ADR-0049 Phase 4: OpenLineage integration for data/code lineage
 RUN pip install --no-cache-dir \

--- a/airflow/dags/vyos_router_deployment.py
+++ b/airflow/dags/vyos_router_deployment.py
@@ -18,8 +18,6 @@ from datetime import datetime, timedelta
 from airflow.models import Variable
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import BranchPythonOperator, PythonOperator
-from airflow.sensors.base import BaseSensorOperator
-from airflow.utils.decorators import apply_defaults
 
 from airflow import DAG
 

--- a/airflow/plugins/qubinode/vault/__init__.py
+++ b/airflow/plugins/qubinode/vault/__init__.py
@@ -35,7 +35,7 @@ __all__ = [
 def __getattr__(name):
     """Lazy load vault components."""
     if name in __all__:
-        from qubinode.vault import operators
+        from . import operators
 
         return getattr(operators, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
Fix Airflow DAG import errors by removing deprecated imports, resolving a circular import, and adding missing dependencies.

The previous Airflow DAG import failures were caused by deprecated imports in `vyos_router_deployment.py`, a circular import in the vault plugin, and missing `pyyaml` (for `dag_factory`) and `graphviz` (for DAG visualization) dependencies in the Dockerfile.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e121953-7ff6-4b96-8983-d814a7622301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4e121953-7ff6-4b96-8983-d814a7622301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolve DAG import failures by removing deprecated imports, fixing a vault relative import, and adding pyyaml/graphviz to the Airflow image.
> 
> - **Airflow DAGs**:
>   - Remove deprecated imports (`BaseSensorOperator`, `apply_defaults`) from `airflow/dags/vyos_router_deployment.py`.
> - **Plugins (Vault)**:
>   - Fix lazy import to use relative path in `airflow/plugins/qubinode/vault/__init__.py` (`from . import operators`).
> - **Dockerfile**:
>   - Add missing dependencies to `airflow/Dockerfile`: `pyyaml>=6.0.0` and `graphviz>=0.20.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edf65768eb4c09839abc724dc383e53187aab9f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->