### PR TITLE
Fix airflow sqlite connection path

### DIFF
--- a/.github/workflows/airflow-validate.yml
+++ b/.github/workflows/airflow-validate.yml
@@ -86,7 +86,7 @@ jobs:
           export AIRFLOW_HOME=$(pwd)
           export AIRFLOW__CORE__DAGS_FOLDER=$(pwd)/dags
           export AIRFLOW__CORE__LOAD_EXAMPLES=false
-          export AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=sqlite:///airflow.db
+          export AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=sqlite:///$(pwd)/airflow.db
 
           # Initialize minimal Airflow DB
           airflow db init


### PR DESCRIPTION
Update SQLite connection string in `airflow-validate.yml` to use an absolute path.

The previous configuration used a relative path (`sqlite:///airflow.db`), which caused an `AirflowConfigException` because Airflow requires an absolute path for SQLite connection strings. The change to `sqlite:///$(pwd)/airflow.db` resolves this by making the path absolute relative to the `airflow` directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3766d1d-0de4-48cb-8f37-55e6771c60bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d3766d1d-0de4-48cb-8f37-55e6771c60bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use an absolute SQLite connection path in the Airflow DAG import validation step to prevent path errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fb0e435f4809e1cecb633caa0c3058fa97fb376. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->