### PR TITLE
Validate airflow dag imports

### DIFF
--- a/airflow/DAG-VALIDATION-FIX.md
+++ b/airflow/DAG-VALIDATION-FIX.md
@@ -1,0 +1,214 @@
+# DAG Validation Issue Fixed
+
+**Date:** December 3, 2025  
+**Status:** ✅ RESOLVED  
+**Agent:** Sophia (Methodological Pragmatism Framework)
+
+---
+
+## Issue Summary
+
+DAG import validation was failing due to a duplicate DAG ID `freeipa_deployment` being generated from two different sources.
+
+### Error Details
+
+```
+AirflowDagDuplicatedIdException: Ignoring DAG freeipa_deployment from 
+/workspace/airflow/dags/freeipa_deployment.py - also found in 
+/workspace/airflow/dags/dag_loader.py
+```
+
+---
+
+## Root Cause Analysis
+
+The project uses two patterns for DAG generation:
+
+1. **Standalone DAG Files** - Manually created Python files with full DAG implementations
+2. **Registry-Generated DAGs** - Auto-generated from `registry.yaml` via the `dag_factory.py` pattern (ADR-0046)
+
+### Conflict Details
+
+| Source | DAG ID | Lines | Type |
+|--------|--------|-------|------|
+| `freeipa_deployment.py` | `freeipa_deployment` | 558 | Standalone, comprehensive multi-stage workflow |
+| `registry.yaml` → `dag_loader.py` | `freeipa_deployment` | Auto-gen | Registry-based, simple deployment pattern |
+
+The `dag_factory.py` generates DAG IDs using the pattern: `{component}_deployment`
+
+So the registry entry `component: freeipa` created the same DAG ID as the standalone file.
+
+---
+
+## Resolution
+
+**Decision:** Keep standalone implementation, comment out registry entry
+
+**Confidence Level:** 95%
+
+### Rationale
+
+1. **Completeness**: The standalone `freeipa_deployment.py` is a mature, well-documented implementation with:
+   - Multi-stage workflow (validate → create → wait → prepare → install → validate)
+   - Branching logic for create/destroy actions
+   - Comprehensive parameter handling
+   - Detailed error handling and logging
+   - Full documentation
+
+2. **Registry Pattern**: The registry-generated version is designed for simpler, standardized deployments that follow the basic pattern:
+   - Validate → Deploy → Destroy
+   - Good for components that fit the standard pattern
+
+3. **Similar Components**: 
+   - `vyos_router_deployment.py` (standalone) and `vyos_deployment` (registry) - NO CONFLICT (different IDs)
+   - `step_ca_deployment.py` (standalone) and `stepca_deployment` (registry) - NO CONFLICT (different IDs)
+   - Only FreeIPA had a naming collision
+
+### Changes Made
+
+Modified `/workspace/airflow/dags/registry.yaml`:
+
+```yaml
+# Before:
+  - component: freeipa
+    description: Deploy FreeIPA Identity Management Server
+    script_path: /opt/kcli-pipelines/freeipa
+    ...
+
+# After:
+  # FreeIPA Identity Management
+  # NOTE: Commented out to avoid conflict with standalone freeipa_deployment.py
+  # The standalone DAG provides more comprehensive multi-stage workflow implementation
+  # - component: freeipa
+  #   description: Deploy FreeIPA Identity Management Server
+  #   script_path: /opt/kcli-pipelines/freeipa
+  #   ...
+```
+
+---
+
+## Verification Results
+
+### Before Fix
+```
+Error: Failed to load all files. For details, run `airflow dags list-import-errors`
+filepath                                | error                                 
+========================================+=======================================
+/workspace/airflow/dags/freeipa_deploym | AirflowDagDuplicatedIdException:      
+ent.py                                  | Ignoring DAG freeipa_deployment...
+```
+
+### After Fix
+```
+[OK] No import errors found
+DAGs Successfully Loaded: 39
+```
+
+### Registry-Generated DAGs Still Working
+- ✅ `vyos_deployment` (from registry.yaml)
+- ✅ `stepca_deployment` (from registry.yaml)
+
+---
+
+## Validation Commands
+
+To reproduce the validation:
+
+```bash
+export AIRFLOW_HOME=$(pwd)/airflow
+export AIRFLOW__CORE__DAGS_FOLDER=$(pwd)/airflow/dags
+export AIRFLOW__CORE__LOAD_EXAMPLES=false
+export AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=sqlite:///$(pwd)/airflow/airflow.db
+
+cd airflow
+airflow db init 2>/dev/null || airflow db migrate 2>/dev/null
+airflow dags list 2>&1 | tee dag_list.txt
+airflow dags list-import-errors
+
+# Check for errors
+if grep -iE "error|exception" dag_list.txt | grep -v "No data found"; then
+  echo "[ERROR] DAG import errors detected"
+  exit 1
+fi
+
+echo "[OK] Validation passed"
+```
+
+---
+
+## Recommendations for Future
+
+### For Development Team
+
+1. **Naming Convention Awareness**: When creating standalone DAG files, be aware of potential conflicts with registry-generated DAGs
+   - Registry generates: `{component}_deployment`
+   - Standalone files should use different patterns if overlapping with registry entries
+
+2. **Documentation**: Both patterns serve different purposes:
+   - **Standalone DAGs**: For complex, multi-stage workflows requiring custom logic
+   - **Registry DAGs**: For simple, standardized deployments following the pattern
+
+3. **Decision Tree**: When to use which pattern?
+
+```
+┌─────────────────────────────────────┐
+│  Need to deploy a new component?   │
+└────────────┬────────────────────────┘
+             │
+             ▼
+   ┌─────────────────────┐
+   │ Complex workflow?   │
+   │ (multi-stage, custom│
+   │  branching, manual  │
+   │  steps, etc.)       │
+   └────────┬────────────┘
+            │
+      ┌─────┴─────┐
+      │           │
+     Yes          No
+      │           │
+      ▼           ▼
+┌─────────────┐  ┌──────────────┐
+│ Standalone  │  │ Registry     │
+│ DAG File    │  │ Entry        │
+└─────────────┘  └──────────────┘
+```
+
+### Related ADRs
+
+- **ADR-0045**: DAG Development Standards
+- **ADR-0046**: DAG Factory Pattern and Host Execution
+- **ADR-0047**: kcli-pipelines Integration
+
+---
+
+## Error Architecture Assessment
+
+### Human-Cognitive Errors Mitigated
+- ✅ Naming collision awareness documented
+- ✅ Clear decision tree for pattern selection
+- ✅ Validation procedure established
+
+### Artificial-Stochastic Errors Mitigated
+- ✅ Pattern completion error (registry + standalone naming)
+- ✅ Consistency check across DAG sources
+- ✅ Systematic validation process implemented
+
+---
+
+## Conclusion
+
+**Status**: DAG import validation now passes successfully ✅
+
+**Impact**: 
+- No functional loss (comprehensive standalone DAG preserved)
+- Registry pattern still functional for other components
+- Clear documentation for future development
+
+**Verification Approach**: Systematic testing with explicit checks for both human and AI error patterns
+
+**Confidence**: 95% - High confidence based on:
+- Successful validation results
+- No import errors
+- All DAGs loading correctly
+- Registry pattern still working for other components

--- a/airflow/dag_list.txt
+++ b/airflow/dag_list.txt
@@ -1,9 +1,6 @@
 /home/ubuntu/.local/lib/python3.12/site-packages/airflow/cli/commands/dag_command.py:48 UserWarning: Could not import graphviz. Rendering graph to the graphical format will not be possible.
-Error: Failed to load all files. For details, run `airflow dags 
-list-import-errors`
 [INFO] Loading DAGs from registry: /workspace/airflow/dags/registry.yaml
 [INFO] Loaded DAG registry from: /workspace/airflow/dags/registry.yaml
-[OK] Generated DAG: freeipa_deployment
 [OK] Generated DAG: vyos_deployment
 [OK] Generated DAG: stepca_deployment
 dag_id                | fileloc              | owners                | is_paused
@@ -24,7 +21,8 @@ example_kcli_vm_provi | /workspace/airflow/d | qubinode              | None
 sioning               | ags/example_kcli_vm_ |                       |          
                       | provisioning.py      |                       |          
 freeipa_deployment    | /workspace/airflow/d | qubinode              | None     
-                      | ags/dag_loader.py    |                       |          
+                      | ags/freeipa_deployme |                       |          
+                      | nt.py                |                       |          
 generic_vm_deployment | /workspace/airflow/d | qubinode              | None     
                       | ags/generic_vm_deplo |                       |          
                       | yment.py             |                       |          

--- a/airflow/dags/registry.yaml
+++ b/airflow/dags/registry.yaml
@@ -26,22 +26,24 @@ dags:
   # ===========================================================================
 
   # FreeIPA Identity Management
-  - component: freeipa
-    description: Deploy FreeIPA Identity Management Server
-    script_path: /opt/kcli-pipelines/freeipa
-    tags: [identity, dns, kerberos, ldap, ipa]
-    category: identity
-    params:
-      action: create
-      community_version: "true"
-      os_version: "9"
-      domain: example.com
-      realm: EXAMPLE.COM
-      idm_hostname: idm
-      dns_forwarder: 8.8.8.8
-    volume_mounts:
-      - /opt/freeipa-workshop-deployer:/opt/freeipa-workshop-deployer
-      - /root/.generated:/root/.generated
+  # NOTE: Commented out to avoid conflict with standalone freeipa_deployment.py
+  # The standalone DAG provides more comprehensive multi-stage workflow implementation
+  # - component: freeipa
+  #   description: Deploy FreeIPA Identity Management Server
+  #   script_path: /opt/kcli-pipelines/freeipa
+  #   tags: [identity, dns, kerberos, ldap, ipa]
+  #   category: identity
+  #   params:
+  #     action: create
+  #     community_version: "true"
+  #     os_version: "9"
+  #     domain: example.com
+  #     realm: EXAMPLE.COM
+  #     idm_hostname: idm
+  #     dns_forwarder: 8.8.8.8
+  #   volume_mounts:
+  #     - /opt/freeipa-workshop-deployer:/opt/freeipa-workshop-deployer
+  #     - /root/.generated:/root/.generated
 
   # ===========================================================================
   # Network Services


### PR DESCRIPTION
Comment out `freeipa` entry in `registry.yaml` to resolve a duplicate DAG ID conflict.

The standalone `freeipa_deployment.py` provides a more comprehensive multi-stage workflow, so its registry-generated counterpart was disabled to prevent `AirflowDagDuplicatedIdException`.

---
<a href="https://cursor.com/background-agent?bcId=bc-0397cfe5-2d53-4901-9c74-7911e9324a68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0397cfe5-2d53-4901-9c74-7911e9324a68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

