### PR TITLE
fix(airflow): Increase webserver memory limit to 2GB

### DIFF
--- a/airflow/docker-compose.yml
+++ b/airflow/docker-compose.yml
@@ -166,8 +166,9 @@ services:
       start_period: 30s
     restart: always
     # ADR-0050: Resource limits for webserver
-    mem_limit: 1g
-    mem_reservation: 512m
+    # Increased from 1g to 2g to prevent crashes on systems with heavy DAG loads
+    mem_limit: 2g
+    mem_reservation: 1g
     ulimits:
       nofile:
         soft: 65536


### PR DESCRIPTION
## Summary

Increase Airflow webserver memory limit from 1GB to 2GB to prevent crashes on systems with heavy DAG loads.

## Changes

| Setting | Before | After |
|---------|--------|-------|
| `mem_limit` | 1g | 2g |
| `mem_reservation` | 512m | 1g |

## Reason

The webserver was crashing on some systems due to insufficient memory when handling heavy DAG loads or complex UI operations.

## Test plan

- [x] Pre-commit checks pass
- [ ] CI pipeline passes
- [ ] Manual testing on affected systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)